### PR TITLE
Background fix

### DIFF
--- a/webimageloader/src/main/java/com/webimageloader/ext/ImageHelper.java
+++ b/webimageloader/src/main/java/com/webimageloader/ext/ImageHelper.java
@@ -138,6 +138,8 @@ public class ImageHelper {
             if (!fadeIn) {
                 v.setImageBitmap(b);
             } else {
+            	v.setImageBitmap(null);
+            	
                 Drawable old = v.getDrawable();
                 if (old == null) {
                     old = new ColorDrawable(android.R.color.transparent);


### PR DESCRIPTION
When using a square image as a placeholder and downloading a rounded corner image (with fade animation), it is important to remove the placeholder and do the fade in animation. android:background and android:src for an imageview are different properties.
