### PR TITLE
Updated Version for Maven Artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ If you are a Maven user, simply add the following to your `pom.xml`:
 <dependency>
     <groupId>com.webimageloader</groupId>
     <artifactId>webimageloader</artifactId>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
 </dependency>
 ``` 
 


### PR DESCRIPTION
Just a little change; updated the version of the maven artifact to the most recent version 1.1.3, to avoid confusion.
