### PR TITLE
Allow users to specify a custom HttpURLConnection.

### DIFF
--- a/webimageloader/src/main/java/com/webimageloader/ConnectionHandler.java
+++ b/webimageloader/src/main/java/com/webimageloader/ConnectionHandler.java
@@ -1,19 +1,23 @@
 package com.webimageloader;
 
+import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.URL;
 
 /**
- * Interface for accessing a {@link HttpURLConnection} before a request is
- * made, this can be used for example doing authentication. This handler is
- * only used for http(s) connections.
+ * Interface for creating an {@link HttpURLConnection} for a request.
+ *
+ * This can be used, for example, for doing HTTP authentication or using a custom HttpURLConnection.
+ * This handler is only used for http(s) connections.
  *
  * @author Alexander Blom <alexanderblom.se>
  */
 public interface ConnectionHandler {
     /**
-     * Called before a request. Note that this method is called from a
-     * background thread.
-     * @param connection the connection
+     * Called before a request. Note that this method is called from a background thread.
+     *
+     * @param url URL to be loaded.
+     * @return The HTTP connection object to be used for this URL.
      */
-    void handleConnection(HttpURLConnection connection);
+    HttpURLConnection handleConnection(URL url) throws IOException;
 }


### PR DESCRIPTION
As discussed in issue #11, this allows the use of libraries like OkHttp to work around various native Android HTTP bugs.

I don't know if these changes were exactly what you were thinking of, but this works well for me (with a patched version of OkHttp which properly handles HTTP 307 redirects).

I tested it with no `ConnectionHandler`, a handler which always returns `null` and a handler which uses OkHttp. Everything worked as expected.
